### PR TITLE
Fedora support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
-    then \
-      wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz && \
-      tar -xf Python-3.6.2.tgz && \
-      pushd Python-3.6.2 && \
-      ./configure && \
-      make -s && \
-      sudo make install -s && \
-      popd; \
-    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
+    wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
+    tar -xf Python-3.6.2.tgz &&
+    pushd Python-3.6.2 &&
+    ./configure &&
+    make -s &&
+    sudo make install -s &&
+    popd; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,15 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xvf Python-3.6.2.tgz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd Python-3.6.2.tgz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install; fi
+
+
+
 script:
   - ./bootstrap.py
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd Python-3.6.2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo make install; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz;
-  tar -xf Python-3.6.2.tgz;
-  pushd Python-3.6.2;
-  ./configure;
-  make -s;
-  sudo make install -s;
-  popd;
-  fi
+      wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz;
+      tar -xf Python-3.6.2.tgz;
+      pushd Python-3.6.2;
+      ./configure;
+      make -s;
+      sudo make install -s;
+      popd;
+    fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xvf Python-3.6.2.tgz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd Python-3.6.2.tgz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd Python-3.6.2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,11 @@ before_install:
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xvf Python-3.6.2.tgz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd Python-3.6.2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd Python-3.6.2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo make install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then popd; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
-  - |
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
-  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
-  tar -xf Python-3.6.2.tgz &&
-  pushd Python-3.6.2 &&
-  ./configure &&
-  make -s &&
-  sudo make install -s &&
-  popd; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz;
+  tar -xf Python-3.6.2.tgz;
+  pushd Python-3.6.2;
+  ./configure;
+  make -s;
+  sudo make install -s;
+  popd;
+  fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,16 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xvf Python-3.6.2.tgz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd Python-3.6.2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo make install; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then popd; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
+  then \
+  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz && \
+  tar -xf Python-3.6.2.tgz && \
+  pushd Python-3.6.2 && \
+  ./configure && \
+  make -s && \
+  sudo make install -s && \
+  popd; \
+  fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
+  - |
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
   wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
   tar -xf Python-3.6.2.tgz &&
   pushd Python-3.6.2 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,26 +16,14 @@ matrix:
 addons:
   apt:
     packages:
-      - valgrind
-      - ruby
-      - ruby-dev
-      - python3-pip
+      - ruby-dev # necessary for md2man
+      - libasan2 # this is optional so must be installed apart of gcc
+      - libtsan0 # this is optional so must be installed apart of gcc
+      - python3.5 # on Travis this should be installed before bootstrap
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
-
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz;
-      tar -xf Python-3.6.2.tgz;
-      pushd Python-3.6.2;
-      ./configure;
-      make -s;
-      sudo make install -s;
-      popd;
-    fi
-
-
 
 script:
   - ./bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
-  then \
-  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz && \
-  tar -xf Python-3.6.2.tgz && \
-  pushd Python-3.6.2 && \
-  ./configure && \
-  make -s && \
-  sudo make install -s && \
-  popd; \
-  fi
+    then \
+      wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz && \
+      tar -xf Python-3.6.2.tgz && \
+      pushd Python-3.6.2 && \
+      ./configure && \
+      make -s && \
+      sudo make install -s && \
+      popd; \
+    fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,23 @@ addons:
   apt:
     packages:
       - ruby-dev # necessary for md2man
-      - libasan2 # this is optional so must be installed apart of gcc
+      - libasan0 # this is optional so must be installed apart of gcc
       - libtsan0 # this is optional so must be installed apart of gcc
-      - python3.5 # on Travis this should be installed before bootstrap
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+
+# there nothing more then python3.4 in trusty repo
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz;
+      tar -xf Python-3.6.2.tgz;
+      pushd Python-3.6.2;
+      ./configure;
+      make -s;
+      sudo make install -s;
+      popd;
+    fi
 
 script:
   - ./bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
-    wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
-    tar -xf Python-3.6.2.tgz &&
-    pushd Python-3.6.2 &&
-    ./configure &&
-    make -s &&
-    sudo make install -s &&
-    popd; fi
+wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
+tar -xf Python-3.6.2.tgz &&
+pushd Python-3.6.2 &&
+./configure &&
+make -s &&
+sudo make install -s &&
+popd; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
-wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
-tar -xf Python-3.6.2.tgz &&
-pushd Python-3.6.2 &&
-./configure &&
-make -s &&
-sudo make install -s &&
-popd; fi
+  wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz &&
+  tar -xf Python-3.6.2.tgz &&
+  pushd Python-3.6.2 &&
+  ./configure &&
+  make -s &&
+  sudo make install -s &&
+  popd; fi
 
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,20 +24,14 @@ if __name__ == "__main__":
 		'debug' :		{ 'type' : 'debug' },
 		'release' :		{ 'type' : 'release' },
 		'plain' :		{ 'type' : 'plain' },
-		'debug-opt' :	{ 'type' : 'debugoptimized', 'grind' : True }
+		'debug-opt' :		{ 'type' : 'debugoptimized', 'grind' : True },
+		'asan' : 		{ 'type' : 'debugoptimized', 'opts' : [ '-Db_sanitize=address' ],
+						'env' : { 'VALGRIND' : '1' }
+		},
+		'tsan' : 		{ 'type' : 'debugoptimized', 'opts' : [ '-Db_sanitize=thread' ],
+						'env' : { 'VALGRIND' : '1' }
+		}
 	}
-
-	# hopeless to run thread sanitizers in travis
-	if 'TRAVIS_OS_NAME' not in os.environ:
-		b = {
-			'asan' : { 'type' : 'debugoptimized', 'opts' : [ '-Db_sanitize=address' ],
-						'env' : { 'VALGRIND' : '1' }
-				},
-			'tsan' : { 'type' : 'debugoptimized', 'opts' : [ '-Db_sanitize=thread' ],
-						'env' : { 'VALGRIND' : '1' }
-				}
-			}
-		builds.update(b)
 
 	for name, build in builds.items():
 		path = 'build-%s' % name

--- a/irequire.py
+++ b/irequire.py
@@ -133,6 +133,13 @@ templates = {
 								[ "sudo", "chmod", "go+rx", "{install_d}/{bin_name}" ]
 							]
 			}
+                        "dnf" :  {
+				"platform" : [ "linux" ],
+				"requires" : [ "dnf" ],
+				"cmd_list" : [
+					[ "sudo", "dnf", "-y", "install", "{pkg_name}" ]
+				]      
+                        }
 		}
 
 class template():
@@ -187,6 +194,7 @@ class template():
 targets = {	"pip3" : {
 				"recipes" : [
 					{ "template" : "apt-get", "recipe" : { "pkg_name" : "python3-pip" } }
+                                        { "template" : "dnf", "recipe" : { "pkg_name" : "python3-pip" } }
 				]
 			},
 			"meson" : {
@@ -204,6 +212,7 @@ targets = {	"pip3" : {
 				},
 				"recipes" : [
 					{ "template" : "apt-get", "recipe" : { "pkg_name" : "ninja-build" } },
+					{ "template" : "dnf", "recipe" : { "pkg_name" : "ninja-build" } },
 					{ "template" : "port", "recipe" : { "pkg_name" : "ninja" } },
 					{ "template" : "zip-install", 
 						"recipe" : { "pkg_name" : "ninja-build", "bin_name" : "ninja",
@@ -222,6 +231,7 @@ targets = {	"pip3" : {
 					{ "template" : "port", "recipe" : { "pkg_name" : "valgrind" } },
 					{ "template" : "brew", "recipe" : { "pkg_name" : "valgrind" } },
 					{ "template" : "apt-get", "recipe" : { "pkg_name" : "valgrind" } }
+					{ "template" : "dnf", "recipe" : { "pkg_name" : "valgrind" } },
 				]
 			}
 		}

--- a/irequire.py
+++ b/irequire.py
@@ -193,7 +193,7 @@ class template():
 # All variables in a target are available for substitution inside recipes.
 targets = {	"pip3" : {
 				"recipes" : [
-					{ "template" : "apt-get", "recipe" : { "pkg_name" : "python3-pip" } }
+					{ "template" : "apt-get", "recipe" : { "pkg_name" : "python3-pip" } },
                                         { "template" : "dnf", "recipe" : { "pkg_name" : "python3-pip" } }
 				]
 			},
@@ -230,7 +230,7 @@ targets = {	"pip3" : {
 				"recipes" : [
 					{ "template" : "port", "recipe" : { "pkg_name" : "valgrind" } },
 					{ "template" : "brew", "recipe" : { "pkg_name" : "valgrind" } },
-					{ "template" : "apt-get", "recipe" : { "pkg_name" : "valgrind" } }
+					{ "template" : "apt-get", "recipe" : { "pkg_name" : "valgrind" } },
 					{ "template" : "dnf", "recipe" : { "pkg_name" : "valgrind" } },
 				]
 			}

--- a/irequire.py
+++ b/irequire.py
@@ -132,7 +132,7 @@ templates = {
 								[ "sudo", "unzip", "-o", "-d", "{install_d}/", "{temp_dir}/{bin_name}.zip" ],
 								[ "sudo", "chmod", "go+rx", "{install_d}/{bin_name}" ]
 							]
-			}
+			},
                         "dnf" :  {
 				"platform" : [ "linux" ],
 				"requires" : [ "dnf" ],


### PR DESCRIPTION
Added Fedora package manager "dnf" that replaced "yum" since Fedora 22 (now we are at Fedora 25).
As a note: to make md2man install correctly is necessary to run following command, before bootstrap.py.
`sudo dnf install -y ruby-devel redhat-rpm-config`

UPDATE: also edited travis.yml to finally see Travis icon green!
Maybe a "not so elegant" solution but it works.
[https://travis-ci.org/alexlab2017/nonlibc/builds/280154187](https://travis-ci.org/alexlab2017/nonlibc/builds/280154187)